### PR TITLE
Update tutorial-azure-linux-migration.md

### DIFF
--- a/articles/azure-linux/tutorial-azure-linux-migration.md
+++ b/articles/azure-linux/tutorial-azure-linux-migration.md
@@ -57,6 +57,7 @@ There are several settings that can block the OS SKU migration request. To ensur
 * An Ubuntu OS SKU with CVM 20.04 enabled can't perform an OS SKU migration.
 * Node pools with Kata enabled can't perform an OS SKU migration.
 * Windows OS SKU migration isn't supported.
+* OS SKU migration from Mariner to Azure Linux is supported, but rolling back to Mariner is not supported.
 
 ### Prerequisites
 
@@ -329,7 +330,7 @@ Once the migration is complete on your test clusters, you should verify the foll
 
 ### Rollback
 
-If you experience issues during the OS SKU migration, you can roll back to your previous OS SKU. To do this, you need to change the OS SKU field in your template and resubmit the deployment, which triggers another upgrade operation and restores the node pool to its previous OS SKU.
+If you experience issues during the OS SKU migration, you can roll back to your previous OS SKU. To do this, you need to change the OS SKU field in your template and resubmit the deployment, which triggers another upgrade operation and restores the node pool to its previous OS SKU. Please note that OS SKU migration does not support rolling back to OS SKU Mariner.
 
 * Roll back to your previous OS SKU using the `az aks nodepool update` command. This command updates the OS SKU for your node pool from Azure Linux back to Ubuntu.
 

--- a/articles/azure-linux/tutorial-azure-linux-migration.md
+++ b/articles/azure-linux/tutorial-azure-linux-migration.md
@@ -330,7 +330,11 @@ Once the migration is complete on your test clusters, you should verify the foll
 
 ### Rollback
 
-If you experience issues during the OS SKU migration, you can roll back to your previous OS SKU. To do this, you need to change the OS SKU field in your template and resubmit the deployment, which triggers another upgrade operation and restores the node pool to its previous OS SKU. Please note that OS SKU migration does not support rolling back to OS SKU Mariner.
+If you experience issues during the OS SKU migration, you can roll back to your previous OS SKU. To do this, you need to change the OS SKU field in your template and resubmit the deployment, which triggers another upgrade operation and restores the node pool to its previous OS SKU.
+
+ > [!NOTE]
+ > 
+ > OS SKU migration does not support rolling back to OS SKU Mariner.
 
 * Roll back to your previous OS SKU using the `az aks nodepool update` command. This command updates the OS SKU for your node pool from Azure Linux back to Ubuntu.
 


### PR DESCRIPTION
Adding note that OS SKU migration is supported for migrating from OS SKU Mariner to OS SKU Azure Linux, and calling out that rolling back to Mariner is not supported