### PR TITLE
Update quickstart-increase-quota-portal.md

### DIFF
--- a/articles/quotas/quickstart-increase-quota-portal.md
+++ b/articles/quotas/quickstart-increase-quota-portal.md
@@ -15,7 +15,7 @@ For more information about quotas, see [Quotas overview](quotas-overview.md).
 
 An Azure account with the Contributor role (or another role that includes Contributor access).
 
-If you don't have an Azure account, create a [free account](https://azure.microsoft.com/free/?WT.mc_id=A261C142F) before you begin.
+If you don't have an Azure account, create a [free account](https://azure.microsoft.com/free/?WT.mc_id=A261C142F) before you begin. However, to adjust quota you will need to upgrade to a paid subscription. For more information on the limitations, see [Azure subscription and service limits, quotas, and constraints](https://learn.microsoft.com/en-us/azure/azure-resource-manager/management/azure-subscription-service-limits#managing-limits). 
 
 ## Request a quota increase
 


### PR DESCRIPTION
The sentence on trial subscriptions is misleading. Trial subscriptions are not eligible for quota increases. This addition should help direct users to understanding the limits of trial subscriptions.