### PR TITLE
Added AzureFrontDoor.FirstParty in the list of service tags required …

### DIFF
--- a/articles/azure-portal/azure-portal-safelist-urls.md
+++ b/articles/azure-portal/azure-portal-safelist-urls.md
@@ -28,7 +28,7 @@ The URL endpoints to allow for the Azure portal are specific to the Azure cloud 
 ### [Public Cloud](#tab/public-cloud)
 
 > [!TIP]
-> The service tags required to access the Azure portal (including authentication and resource listing) are **AzureActiveDirectory**, **AzureResourceManager**, and **AzureFrontDoor.Frontend**. Access to other services may require additional permissions, as described below.  
+> The service tags required to access the Azure portal (including authentication and resource listing) are **AzureActiveDirectory**, **AzureResourceManager**, **AzureFrontDoor.Frontend**, and **AzureFrontDoor.FirstParty**. Access to other services may require additional permissions, as described below.  
 > However, there is a possibility that unnecessary communication other than communication to access the portal may also be allowed. If granular control is required, FQDN-based access control such as Azure Firewall is required.
 
 #### Azure portal authentication


### PR DESCRIPTION
…to access Azure Portal

■Issue & Conclusion
When tried to access "portal.azure.com" from VMs in Azure, it doesn't work unless we add "AzureFrontDoor.FirstParty" in the allowed service tag.

■TroubleShooting

After nslookup portal.azure.com:
ーーーーーーーーーーーーーーーーーーーーーー
> nslookup portal.azure.com
Server:  UnKnown
Address:  168.63.129.16
Non-authoritative answer:
Name:    s-part-0027.p-0010.p-msedge.net
Addresses:  2603:1061:11::27
  150.171.84.27
Aliases:  portal.azure.com
         portal.azure.com.trafficmanager.net
         azureportal.z01.azurefd.net
         azurefd-p-prod.trafficmanager.net
         shed.s-part-0027.p-0010.p-msedge.net
ーーーーーーーーーーーーーーーーーーーーーー

No answer from 150.171.84.27 
-> The IP is actually included in "AzureFrontDoor.FirstParty" service tag.

[Download Azure IP Ranges and Service Tags – Public Cloud from Official Microsoft Download Center](https://www.microsoft.com/en-us/download/details.aspx?id=56519)
Azure IP Ranges and Service Tags – Public Cloud

MicrosoftIPs
{
      "name": "AzureFrontDoor.FirstParty",
      "id": "AzureFrontDoor.FirstParty",
      "properties": {
        "changeNumber": 17,
        "region": "",
        "regionId": 0,
        "platform": "Azure",
        "systemService": "AzureFrontDoor",
        "addressPrefixes": [
          "13.107.3.0/24",
          "13.107.4.0/22",
          "13.107.9.0/24",
          "13.107.12.0/23",
          "13.107.15.0/24",
          "13.107.16.0/24",
          "13.107.18.0/23",
          "13.107.21.0/24",
          "13.107.22.0/24",
          "13.107.37.0/24",
          "13.107.38.0/23",
          "13.107.40.0/24",
          "13.107.42.0/23",
          "13.107.48.0/24",
          "13.107.50.0/24",
          "13.107.52.0/24",
          "13.107.54.0/24",
          "13.107.56.0/24",
          "13.107.64.0/18",
          "13.107.128.0/19",
          "13.107.245.0/24",
          "13.107.254.0/23",
          "131.253.3.0/24",
          "131.253.21.0/24",
          "131.253.33.0/24",
          "150.171.24.0/23",
          "150.171.27.0/24",
          "150.171.28.0/23",
          "150.171.30.0/24",
          "150.171.32.0/19",
          "150.171.65.0/24",
          "150.171.66.0/23",
          "150.171.69.0/24",
          "150.171.70.0/23",
          "150.171.72.0/21",
          "150.171.82.0/23",
          "150.171.84.0/22",
          "150.171.88.0/23",

■Testing
1. When having only AzureActiveDirectory, AzureResourceManager, and AzureFrontDoor.Frontend service tags allowed in the firewall.
-> No access to Azure Portal in the browser either

![image](https://github.com/user-attachments/assets/7db3dee9-2e04-4fe7-b45b-307e70f702db)


2. When having all AzureActiveDirectory, AzureResourceManager, AzureFrontDoor.Frontend and AzureFrontDoor.FirstParty service tags.

![image](https://github.com/user-attachments/assets/eecdeaf2-f309-4ff7-9083-55f51b8eb719)
