### PR TITLE
Update TTL for ACR auth token

### DIFF
--- a/articles/container-registry/container-registry-authentication.md
+++ b/articles/container-registry/container-registry-authentication.md
@@ -116,7 +116,7 @@ Using `Connect-AzContainerRegistry` with Azure identities provides [Azure role-b
 
 If you assign a [service principal](/azure/active-directory/develop/app-objects-and-service-principals) to your registry, your application or service can use it for headless authentication. Service principals allow [Azure role-based access control (Azure RBAC)](/azure/role-based-access-control/role-assignments-portal) to a registry, and you can assign multiple service principals to a registry. Multiple service principals allow you to define different access for different applications.
 
-ACR authentication token gets created upon login to the ACR, and is refreshed upon subsequent operations. The time to live for that token is 3 hours.
+ACR authentication token gets created upon login to the ACR, and is refreshed upon subsequent operations. The time to live for that token is 75 minutes.
 
 The available roles for a container registry include:
 


### PR DESCRIPTION
It seems like the ACR token for service principals has a TTL of 75 minutes, not 3 hours like it said in the documentation. This change updates the documentation to be accurate.

I'm using [External Secrets](https://external-secrets.io/) to populate an [`imagePullSecret`](https://kubernetes.io/docs/concepts/containers/images/#using-a-private-registry) in Kubernetes with a token using the [`ACRAccessToken`](https://external-secrets.io/latest/api/generator/acr/) generator, using credentials for a Service Principal. I have configured the `ACRAccessToken` generator to refresh every 3 hours since that's the TTL that it said in the docs for "ACR authentication token" for a Service Principal:

https://github.com/MicrosoftDocs/azure-management-docs/blob/83727a4d8988b262b1b5bb4c62aaaaa9b5808afb/articles/container-registry/container-registry-authentication.md?plain=1#L119

Yet, I'm finding that the tokens I get only have a TTL of 75 minutes:

```console
$ kubectl get secret regcred -o jsonpath='{ .data.\.dockerconfigjson }' | base64 -d | jq -r '.auths."example.azurecr.io".password' | cut -d . -f 2 | base64 -d | jq '.nbf,.exp,.iat' | awk '{ print strftime("%Y-%m-%d %H:%M:%S", $1) }'
2024-11-25 08:15:08
2024-11-25 09:30:08
2024-11-25 08:15:08
```

So now I'm trying to understand if the documentation is wrong or if I found the wrong documentation. I'm noting that you use the term "authentication token", not "access token", so perhaps I'm looking at the wrong thing. Am I?

If I'm right, I think we should merge this PR to fix the documentation. If I'm wrong, do you have any idea where I can find the documentation for the ACR Access Token? 🙏