### PR TITLE
Amend the example given to create the kubernetes secret

### DIFF
--- a/articles/container-registry/container-registry-auth-kubernetes.md
+++ b/articles/container-registry/container-registry-auth-kubernetes.md
@@ -39,7 +39,7 @@ Kubernetes uses an *image pull secret* to store information needed to authentica
 Create an image pull secret with the following `kubectl` command:
 
 ```console
-kubectl create secret docker-registry <secret-name> \
+kubectl create secret acr-secret <secret-name> \
     --namespace <namespace> \
     --docker-server=<container-registry-name>.azurecr.io \
     --docker-username=<service-principal-ID> \


### PR DESCRIPTION
The example given when creating a secret in kubernetes does not match the name in use when using a reference to an imagePullSecret.

In the current version imagePullSecret refers to an acr-secret, but the the kubectl command is creating as docker-registry, which can be misleading