### PR TITLE
Update agent-release-notes.md - Adding information about scheduled task in Azure Connected Machine agent v1.48

### DIFF
--- a/articles/azure-arc/servers/agent-release-notes.md
+++ b/articles/azure-arc/servers/agent-release-notes.md
@@ -41,6 +41,8 @@ Download for [Windows](https://aka.ms/AzureConnectedMachineAgent) or [Linux](man
 - Improved error reporting for `azcmagent` commands.
 - Increased connectivity check timeout for better reliability.
 - Expanded ARM64 platform support to include RHEL 9.
+- Introduced a scheduled task that checks for agent updates on a daily basis. Currently, the update mechanism is inactive and no changes are made to your server even if a newer agent version is available. In the future, you'll be able to schedule updates of the Azure Connected Machine agent from Azure. For more information, see [Automatic agent upgrades](manage-agent.md#automatic-agent-upgrades).
+
 
 ## Version 1.47 - October 2024
 


### PR DESCRIPTION
Adding info about the new scheduled task that was added to agent v1.48 as part of the new (yet to be released) auto agent upgrade feature.

This was originally released in v1.30 - https://learn.microsoft.com/en-us/azure/azure-arc/servers/agent-release-notes-archive#version-130---may-2023

Then removed in agent version 1.37 - https://learn.microsoft.com/en-us/azure/azure-arc/servers/agent-release-notes-archive#fixed

However, we have discovered it has been rereleased in agent v1.48 even though the full functionality is not yet ready. We've had some support cases asking about the scheduled task, so would be good to have this documented in the release notes to be able to direct customers to. The PG have admitted/acknowledged internally to our team that this should be in the release notes.