### PR TITLE
Update arc-gateway.md

### DIFF
--- a/articles/azure-arc/servers/arc-gateway.md
+++ b/articles/azure-arc/servers/arc-gateway.md
@@ -170,7 +170,7 @@ You can configure existing Azure Arc resources to use Arc gateway by using the A
         --base-provider Microsoft.HybridCompute
         --base-resource-type machines
         --base-resource-name [Arc-Server’s name]
-        --settings-resource-name default--gateway-resource-id [Full Arm resource id of the new Arc gateway resource]
+        --gateway-resource-id [Full Arm resource id of the new Arc gateway resource]
     ```
 1. Update your Arc-enabled server to use Arc gateway by running the following command:
 


### PR DESCRIPTION
Removed --settings-resource-name default from the CLI command as it was incorrect, and it wasn't part of the arcgateway extension for the Azure CLI https://learn.microsoft.com/en-us/cli/azure/arcgateway/settings?view=azure-cli-latest