### PR TITLE
Proposal to change REST Method to PATCH

### DIFF
--- a/articles/azure-arc/servers/windows-server-management-overview.md
+++ b/articles/azure-arc/servers/windows-server-management-overview.md
@@ -114,7 +114,7 @@ $data = @{
     }; 
 }; 
 $json = $data | ConvertTo-Json; 
-$response = Invoke-RestMethod -Method PUT -Uri $uri.AbsoluteUri -ContentType $contentType -Headers $header -Body $json; 
+$response = Invoke-RestMethod -Method PATCH -Uri $uri.AbsoluteUri -ContentType $contentType -Headers $header -Body $json; 
 $response.properties
 ```
 ---


### PR DESCRIPTION
I am proposing the REST method used be changed to PATCH from PUT because using PUT without supplying the rest of the current configuration state of the Arc-enabled Server in the JSON body will remove a server's Extended Security Update license configuration. 

Unless a user is aware of this, using the code as-is can degrade security posture. Using PUT without supplying the rest of the current configuration state can also lead to other unexpected outcomes in the future.