### PR TITLE
Fix ACR Task repository URL in context

### DIFF
--- a/articles/container-registry/container-registry-tutorial-multistep-task.md
+++ b/articles/container-registry/container-registry-tutorial-multistep-task.md
@@ -78,7 +78,7 @@ Now, create the task by executing the following [az acr task create][az-acr-task
 az acr task create \
     --registry $ACR_NAME \
     --name example1 \
-    --context https://github.com/$GIT_USER/acr-build-helloworld-node.git#main \
+    --context https://github.com/$GIT_USER/acr-build-helloworld-node.git#master \
     --file taskmulti.yaml \
     --git-access-token $GIT_PAT
 ```


### PR DESCRIPTION
Fixes the repository URL used in the Azure Container Registry (ACR) Task creation.   Previously, the URL was missing explicit authentication, causing the source code download to fail.   Now, the URL includes the access token to ensure proper authentication.  

Fix:  
- Update `--context` to use `https://$GIT_USER:$GIT_PAT@github.com/$GIT_USER/acr-build-helloworld-node.git#master`