### PR TITLE
Update arc-gateway.md - Correcting the directory locations of the arcproxy.log file for both Windows and Linux

### DIFF
--- a/articles/azure-arc/servers/arc-gateway.md
+++ b/articles/azure-arc/servers/arc-gateway.md
@@ -375,12 +375,12 @@ You can audit your Arc gateway’s traffic by viewing the Azure Arc proxy logs.
 To view Arc proxy logs on **Windows**:
 
 1. Run `azcmagent logs` in PowerShell.
-1. In the resulting .zip file, the logs are located in the `C:\ProgramData\Microsoft\ArcProxy` folder.
+1. In the resulting .zip file, the `arcproxy.log` file is located in the `ProgramData\AzureConnectedMachineAgent\Log` folder.
 
 To view Arc proxy logs on **Linux**:
 
-1. Run `sudo azcmagent logs`and share the resulting file.
-1. In the resulting log file, the logs are located in the `/usr/local/arcproxy/logs/` folder.
+1. Run `sudo azcmagent logs`.
+1. In the resulting .zip file, the `arcproxy.log` file is located in the `/var/opt/azcmagent/log/` folder.
 
 ## Additional scenarios
 


### PR DESCRIPTION
Correcting the directory locations of the arcproxy.log file for both Windows and Linux. Neither of these directories appear to exist: -

Windows - C:\ProgramData\Microsoft\ArcProxy
Linux - /usr/local/arcproxy/logs/

The arcproxy.log file is located in the following locations: -

Windows - C:\ProgramData\AzureConnectedMachineAgent\Log 
Linux - /var/opt/azcmagent/log/

Two other amendments: -
- Removed 'C:\' from the Windows line, as this would not show in a .zip file collected via azcmagent logs.
- Stated the Linux log collection via azcmagent logs is also a .zip file.

Tested/verified this with Windows/Linux machines running ACMA version 1.51 and had machines connected to an Arc Gateway.