### PR TITLE
Added NOTARY_COMMAND_ERROR to container-registry-health-error-reference.md

### DIFF
--- a/articles/container-registry/container-registry-health-error-reference.md
+++ b/articles/container-registry/container-registry-health-error-reference.md
@@ -109,7 +109,7 @@ This error means that the CLI isn't compatible with the currently installed vers
 
 ## NOTARY_COMMAND_ERROR
 
-This error means that Notary client CLI couldn't be found. AS a result the notary checks aren't run.
+This error means that Notary client CLI couldn't be found. As a result the notary checks aren't run.
 
 *Potential solutions*: Install Notary client; add Notary path to the system variables.
 

--- a/articles/container-registry/container-registry-health-error-reference.md
+++ b/articles/container-registry/container-registry-health-error-reference.md
@@ -107,6 +107,12 @@ This error means that the CLI was unable to find the login server of the given r
 
 This error means that the CLI isn't compatible with the currently installed version of Docker/Notary. Try downgrading your notary.exe version to a version earlier than 0.6.0 by replacing your Docker installation's Notary client manually to resolve this issue. You can also try downloading and installing a pre-compiled binary of Notary earlier than 0.6.0 for 64 bit Linux or macOS X from the Notary repository's releases page on GitHub. For windows download the .exe, place it in the(default path:  C:\ProgramFiles\Docker\Docker\resources\bin) and rename it to notary.exe. 
 
+## NOTARY_COMMAND_ERROR
+
+This error means that Notary client CLI couldn't be found. AS a result the notary checks aren't run.
+
+*Potential solutions*: Install Notary client; add Notary path to the system variables.
+
 ## CONNECTIVITY_TOOMANYREQUESTS_ERROR
 
 This error means that the user has sent too many requests in a short period causing the authentication system to block further requests to prevent overload. This error occurs by reaching a configured limit in the user's registry service tier or environment. We recommend waiting for a moment before sending another request. This will allow the authentication system's block to lift and you can try sending a request again.  


### PR DESCRIPTION
Adding section on `NOTARY_COMMAND_ERROR` to articles/container-registry/container-registry-health-error-reference.md as it is missing and referenced by the CLI.

![Screenshot 2025-05-13 140410](https://github.com/user-attachments/assets/96f77af3-2124-4f82-aaf2-8aa085fe4a12)
