### PR TITLE
Add Azure CLI instructions for assigning Extension Identity permissions

### DIFF
--- a/articles/azure-arc/container-storage/cloud-ingest-edge-volume-configuration.md
+++ b/articles/azure-arc/container-storage/cloud-ingest-edge-volume-configuration.md
@@ -65,6 +65,8 @@ az k8s-extension list --cluster-name ${CLUSTER_NAME} --resource-group ${RESOURCE
 
 #### Add Extension Identity permissions to a storage account
 
+##### [Azure portal](#tab/portal)
+
 1. Navigate to storage account in the Azure portal.
 1. Select **Access Control (IAM)**.
 1. Select **Add+ -> Add role assignment**.
@@ -73,6 +75,26 @@ az k8s-extension list --cluster-name ${CLUSTER_NAME} --resource-group ${RESOURCE
 1. To add your principal ID to the **Selected Members:** list, paste the ID and select **+** next to the identity.
 1. Click **Select**.
 1. To review and assign permissions, select **Next**, then select **Review + Assign**.
+
+##### [Azure CLI](#tab/cli)
+
+In Azure CLI, enter your values for the variables (`STORAGE_ACCOUNT_NAME`, `RESOURCE_GROUP`, `PRINCIPAL_ID`) and run the following command:
+
+1. **Set your storage account variables:**  
+   ```sh
+   STORAGE_ACCOUNT_NAME=<your-storage-account-name>
+   RESOURCE_GROUP=<your-resource-group>
+   PRINCIPAL_ID=<your-extension-identity-principal-ID-from-the-previous-section>
+   ```
+
+2. **Assign the `Storage Blob Data Owner` role to your Extension Identity:**  
+   ```sh
+   az role assignment create --assignee $PRINCIPAL_ID --role "Storage Blob Data Owner" --scope /subscriptions/<your-subscription-id>/resourceGroups/$RESOURCE_GROUP/providers/Microsoft.Storage/storageAccounts/$STORAGE_ACCOUNT_NAME
+   ```
+
+   This command assigns the `Storage Blob Data Owner` role to the specified identity at the scope of your storage account.
+
+---
 
 ## Create a Cloud Ingest Persistent Volume Claim (PVC)
 


### PR DESCRIPTION
This PR enhances the "Add Extension Identity permissions to a storage account" section in the Cloud Ingest Edge Volumes configuration documentation by including an Azure CLI tab. The new instructions provide users with an alternative to the Azure portal for assigning the `Storage Blob Data Owner` role to the Extension Identity. 

Key changes:
- Added Azure CLI steps for setting storage account variables.
- Included the `az role assignment create` command to assign the required role.
- Ensured consistency with existing documentation structure.

This update improves usability by offering a CLI-based approach for users who prefer automation or scripting. Let me know if further adjustments are needed!