### PR TITLE
Fixed Azure CLI command in tutorial-use-gitops-argocd.md

### DIFF
--- a/articles/azure-arc/kubernetes/tutorial-use-gitops-argocd.md
+++ b/articles/azure-arc/kubernetes/tutorial-use-gitops-argocd.md
@@ -145,7 +145,7 @@ az k8s-extension create --resource-group <resource-group> --cluster-name <cluste
 --version 0.0.7-preview \
 --config deployWithHightAvailability=false \
 --config namespaceInstall=false \
-–-config "config-maps.argocd-cmd-params-cm.data.application\.namespaces=namespace1,namespace2"
+--config "config-maps.argocd-cmd-params-cm.data.application\.namespaces=namespace1,namespace2"
 ```
 
 If you want to limit ArgoCD access to a specific namespace, use the `--config namespaceInstall=true` along with `--target-namespace <namespace>` parameters. This installation command creates a new `<namespace>` namespace and installs the ArgoCD components in the `<namespace>`. The installation command also enables the ability to install multiple instances of ArgoCD in the same cluster. ArgoCD application definitions in this configuration only function in the `<namespace>` namespace.


### PR DESCRIPTION
Fixed wrong - in Azure CLI command to install ArgoCD components, which made the command unusable