### PR TITLE
Update set-preferences.md

### DIFF
--- a/articles/azure-portal/set-preferences.md
+++ b/articles/azure-portal/set-preferences.md
@@ -209,7 +209,7 @@ This pane lets you manage pop-up notifications and session timeouts.
 
 ### Signing out
 
-The inactivity timeout setting helps to protect resources from unauthorized access if you forget to secure your workstation. Your session will automatically terminate when the device’s active focus is not on the Azure Portal for the period defined in the "Signing out + notifications" setting. As an individual, you can change the timeout setting for yourself. If you're an admin, you can set it at the directory level for all your users in the directory.
+The inactivity timeout setting helps to protect resources from unauthorized access if you forget to secure your workstation. Your session will automatically terminate when the device’s active focus is not on the Azure portal for the period defined in the "Signing out + notifications" setting. As an individual, you can change the timeout setting for yourself. If you're an admin, you can set it at the directory level for all your users in the directory.
 
 ### Change your individual timeout setting (user)
 


### PR DESCRIPTION
* `articles/azure-portal/set-preferences.md`: Updates the explanation of the inactivity timeout setting to specify that sessions terminate when the device’s active focus is not on the Azure Portal for the defined period in the "Signing out + notifications" setting.
 
The new version, with the usage of "active focus" hopefully clarifies that the user needs to tab out or click outside of the Portal for the inactivity timer to start.