### PR TITLE
Fixed url in Bicep script

### DIFF
--- a/articles/azure-arc/kubernetes/tutorial-use-gitops-argocd.md
+++ b/articles/azure-arc/kubernetes/tutorial-use-gitops-argocd.md
@@ -166,7 +166,7 @@ var clusterName = '<aks-or-arc-cluster-name>'
 var workloadIdentityClientId = 'replace-me##-##-###-###'
 var ssoWorkloadIdentityClientId = 'replace-me##-##-###-###'
 
-var url = 'https://<public-ip-for-argocd-ui>/auth/callback'
+var url = 'https://<public-ip-for-argocd-ui>/'
 var oidcConfig = '''
 name: Azure
 issuer: https://login.microsoftonline.com/<your-tenant-id>/v2.0


### PR DESCRIPTION
The url in the Bicep script is wrong `var url = 'https://<public-ip-for-argocd-ui>/auth/callback'` leading to the following error upon login: 
 
AADSTS50011: The redirect URI 'https://<ARGOCD_UI_URL>/auth/callback/auth/callback' specified in the request does not match the redirect URIs configured for the application 'XXX'

The correct url is `https://<public-ip-for-argocd-ui>/` which is also mentioned in the [argo-cd documentation](https://github.com/argoproj/argo-cd/blob/master/docs/operator-manual/user-management/microsoft.md#configure-argo-to-use-the-new-entra-id-app-registration) which is linked further down.

`url: https://argocd.example.com/ # Replace with the external base URL of your Argo CD`