### PR TITLE
Linux ENV override for Arc fix

### DIFF
--- a/articles/azure-arc/servers/plan-evaluate-on-azure-virtual-machine.md
+++ b/articles/azure-arc/servers/plan-evaluate-on-azure-virtual-machine.md
@@ -48,7 +48,7 @@ When Azure Arc-enabled servers is configured on the VM, you see two representati
 > For Linux, set the environment variable to override the ARC on an Azure VM installation. Also set it in the environment of daemons.
 > ```bash
 > export MSFT_ARC_TEST=true
-> systemctl set-environment MSFT_ARC_TEST=true
+> sudo systemctl set-environment MSFT_ARC_TEST=true
 > ```
 
 1. Remove any VM extensions on the Azure VM.


### PR DESCRIPTION
Added sudo to the systemc1 set-enviroment command for Linux distros. This command needs to be ran in sudo to set an environment variable or it will be denied on all distros.